### PR TITLE
Improve readability of player mode cards

### DIFF
--- a/components/ProductivityBinauralPlayer.tsx
+++ b/components/ProductivityBinauralPlayer.tsx
@@ -500,7 +500,7 @@ export default function ProductivityBinauralPlayer() {
                       </div>
                       
                       {/* Enhanced title with gradient text */}
-                      <h3 className="font-heading font-semibold text-fluid-lg mb-4 sm:mb-6 tracking-wide leading-tight gradient-text-premium">
+                      <h3 className="font-heading font-semibold text-fluid-lg mb-4 sm:mb-6 tracking-wide leading-tight text-foreground">
                         {mode.name}
                       </h3>
                       
@@ -514,7 +514,7 @@ export default function ProductivityBinauralPlayer() {
                         <div className="text-xs text-muted-foreground font-medium mb-2 tracking-wider uppercase">
                           Frequency
                         </div>
-                        <div className="text-lg font-mono font-semibold text-primary tracking-wide">
+                        <div className="text-lg font-mono font-semibold text-foreground tracking-wide">
                           {mode.frequency} Hz
                         </div>
                       </div>

--- a/components/frequency-presets.tsx
+++ b/components/frequency-presets.tsx
@@ -39,7 +39,7 @@ export function FrequencyPresets({ onSelectPreset, currentPreset }: FrequencyPre
           >
             <span className="font-bold text-left w-full mb-1">{preset.name}</span>
             <span className="text-xs sm:text-sm text-muted-foreground truncate w-full text-left leading-relaxed">{preset.description}</span>
-            <span className="text-xs font-mono text-primary mt-1 opacity-75">{preset.beatFrequency} Hz</span>
+            <span className="text-xs font-mono text-foreground mt-1">{preset.beatFrequency} Hz</span>
           </Button>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- improve mode card title color
- make frequency value text use higher-contrast color

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874ff2e840c832ea3059e6184356b19